### PR TITLE
Don't import purestorage from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
-import purestorage
-
 from setuptools import setup
 
 setup(
     name="purestorage",
-    version=purestorage.VERSION,
+    version="1.4.0",
     description="Pure Storage FlashArray REST Client",
     keywords=["pure", "storage", "flasharray", "rest", "client"],
     url="",


### PR DESCRIPTION
If the "requests" module has not been installed yet, importing "purestorage"
in setup.py tries to import "requests" and fails. This makes it impossible to
install "requests" and "purestorage" in a single command or requirements file.