### PR TITLE
Adding Timeout Error catch

### DIFF
--- a/purestorage/purestorage.py
+++ b/purestorage/purestorage.py
@@ -15,7 +15,6 @@ from distutils.version import LooseVersion
 # The current version of this library.
 VERSION = "1.16.0"
 
-
 class FlashArray(object):
 
     """Represents a Pure Storage FlashArray and exposes administrative APIs.
@@ -161,6 +160,8 @@ class FlashArray(object):
         try:
             response = requests.request(method, url, data=body, headers=headers,
                                         cookies=self._cookies, **self._request_kwargs)
+        except requests.exceptions.ConnectTimeout as timeouterr:
+            raise PureError(timeouterr)
         except requests.exceptions.RequestException as err:
             # error outside scope of HTTP status codes
             # e.g. unable to resolve domain name
@@ -3761,4 +3762,3 @@ class PureHTTPError(PureError):
                "version {1} at {2}: {3}\n{4}")
         return msg.format(self.code, self.rest_version, self.target,
                           self.reason, self.text)
-


### PR DESCRIPTION
So testing the lib I found out there is no catching for timeout exception (i.e. the cluster is down, the IP is wrong, etc.), this PR fixes that.

```
>>> import urllib3
>>>
>>> from purestorage import FlashArray
>>> from purestorage import PureError
>>>
>>> urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
>>>
>>> timeout=10
>>> cluster="MYIP"
>>>
>>> try:
...     array = FlashArray(cluster, api_token="MY_TOKEN", request_kwargs={'timeout':timeout})
... except PureError as err:
...     print("PureError timeout while connecting to the cluster {0}. Error: {1}".format(cluster, err))
...

PureError timeout while connecting to the cluster MYIP. Error: PureError: HTTPSConnectionPool(host='MYIP', port=443): Max retries exceeded with url: /api/api_version (Caused by ConnectTimeoutError(<urllib3.connection.VerifiedHTTPSConnection object at 0x7f9a89b05128>, 'Connection to MYIP timed out. (connect timeout=10)'))
```